### PR TITLE
Add link page as constant reference for social media

### DIFF
--- a/content/pages/links.md
+++ b/content/pages/links.md
@@ -1,0 +1,13 @@
+---
+title: 'Links'
+header:
+  title: 'Links'
+  subtitle: 'Unsere Links aus Social Media und Co.'
+  image: '/assets/backgrounds/homepage.jpg'
+---
+
+### Aktuell keine Links
+
+Schaut gerne später wieder vorbei.
+
+[icon:link|Hier geht's zu unserem Instagram-Account](https://www.instagram.com/iwi_fachschaft/)

--- a/pages/links.tsx
+++ b/pages/links.tsx
@@ -1,0 +1,25 @@
+import { GetStaticProps } from 'next'
+import MarkdownLoader from '../components/util/markdown-loader'
+import StaticPage from '../components/common/static-page'
+
+function Page({content, data}) {
+    return (
+        <StaticPage
+            className=""
+            data={data}
+            content={content}
+        />
+    )
+}
+
+export default Page
+
+export const getStaticProps: GetStaticProps = async (context) => {
+    const markdown = await MarkdownLoader.single('pages', 'links')
+    return { 
+        props: {
+            content: markdown.content,
+            data: markdown.data
+        }
+    }
+}


### PR DESCRIPTION
Would be available at `iwi-hka.de/links` and could be easily managed by the Social Media team.

Closes #70 