### PR TITLE
Implement and style user account menu

### DIFF
--- a/components/common/menu.tsx
+++ b/components/common/menu.tsx
@@ -12,8 +12,8 @@ const mainMenuItems = [
 ]
 
 const userMenuItems = [
-    { title: 'Registrierung', link: 'https://registration.iwi-hka.de', icon: faUserPlus },
     { title: 'Nextcloud', link: 'https://cloud.iwi-hka.de', icon: faCloud },
+    { title: 'Registrierung', link: 'https://registration.iwi-hka.de', icon: faUserPlus },
 ]
 
 function Menu() {
@@ -28,7 +28,7 @@ function Menu() {
                 </ul>
                 <div className="dropdown hidden md:block relative">
                     <img src="/assets/user.png" alt="Zugang zum internen Bereich" className="md:h-8"/>
-                    <div className="dropdown-menu top-0 right-0 absolute h-auto flex pt-12 hidden w-[220px]">
+                    <div className="dropdown-menu top-0 right-0 absolute h-auto flex pt-4 mt-8 hidden w-[220px]">
                         <ul className="block w-full bg-white list-none border-t-4 border-red-700">
                             { userMenuItems.map(item => { return userMenuItem(item.title, item.link, item.icon)}) }
                         </ul>

--- a/components/common/menu.tsx
+++ b/components/common/menu.tsx
@@ -96,11 +96,13 @@ function mobileMenuItem(title, href) {
 function userMenuItem(title, href, icon) {
     return (
         <li key={ href } className="px-8 py-4">
-            <Link href={ href }>
-                <span className="block cursor-pointer text-gray-700 no-underline font-heading font-bold">
-                    <FontAwesomeIcon icon={ icon } className="mr-4" fixedWidth />
-                    { title }
-                </span>
+            <Link href={ href } passHref>
+                <a title={title}>
+                    <span className="block cursor-pointer text-gray-700 no-underline font-heading font-bold">
+                        <FontAwesomeIcon icon={ icon } className="mr-4" fixedWidth />
+                        { title }
+                    </span>
+                </a>
             </Link>
         </li>
     )

--- a/components/common/menu.tsx
+++ b/components/common/menu.tsx
@@ -1,14 +1,19 @@
 import Link from "next/link"
 import { useRouter } from 'next/router'
-import { faBars, faTimes } from "@fortawesome/free-solid-svg-icons"
+import { faBars, faCloud, faTimes, faUserPlus } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 
-const items = [
+const mainMenuItems = [
     { title: "Erstsemester", slug: "/erstiinfos/" },
     { title: "Wer sind wir?", slug: "/werwirsind/" },
     { title: "Wissenswertes", slug: "/faq/" },
     { title: "Sponsoring & Kooperation", slug: "/unternehmen/" },
     { title: "Kontakt", slug: "/kontakt/" },
+]
+
+const userMenuItems = [
+    { title: 'Registrierung', link: 'https://registration.iwi-hka.de', icon: faUserPlus },
+    { title: 'Nextcloud', link: 'https://cloud.iwi-hka.de', icon: faCloud },
 ]
 
 function Menu() {
@@ -19,11 +24,16 @@ function Menu() {
                     <img src="/assets/iwi-logo.svg" alt="IWI-Logo" className="h-16 md:h-24"/>
                 </a></Link>
                 <ul className="flex list-none">
-                    { items.map(item => { return menuItem(item.title, item.slug)}) }
+                    { mainMenuItems.map(item => { return menuItem(item.title, item.slug)}) }
                 </ul>
-                <Link href="/"><a className="hidden md:block">
+                <div className="dropdown hidden md:block relative">
                     <img src="/assets/user.png" alt="Zugang zum internen Bereich" className="md:h-8"/>
-                </a></Link>
+                    <div className="dropdown-menu top-0 right-0 absolute h-auto flex pt-12 hidden w-[220px]">
+                        <ul className="block w-full bg-white list-none border-t-4 border-red-700">
+                            { userMenuItems.map(item => { return userMenuItem(item.title, item.link, item.icon)}) }
+                        </ul>
+                    </div>
+                </div>
                 <a className="text-2xl mx-2 block md:hidden text-red-700 cursor-pointer modal-open">
                 <FontAwesomeIcon icon={faBars} />
                 </a>
@@ -59,14 +69,12 @@ function mobileMenu() {
                 </div>
                 <div className="modal-content container mx-auto h-auto text-center pt-8">
                     <ul className="list-none">
-                        { items.map(item => { return mobileMenuItem(item.title, item.slug)}) }
+                        { mainMenuItems.map(item => { return mobileMenuItem(item.title, item.slug)}) }
                     </ul>
                     <hr className="border-t-2 border-gray-400 mt-4 mb-8 w-3/4 m-auto" />
-                    <p className="w-1/2 m-auto py-2 pl-8" style={{ background: 'url("/assets/user.png") no-repeat left 50%' }}>
-                        <Link href="/"><a className="block text-xl text-gray-700 no-underline font-heading font-bold">
-                            Mein Account
-                        </a></Link>
-                    </p>
+                    <ul className="list-none">
+                        { userMenuItems.map(item => { return mobileMenuItem(item.title, item.link)}) }
+                    </ul>
                 </div>
             </div>
         </div>
@@ -80,6 +88,19 @@ function mobileMenuItem(title, href) {
                 <a className="text-xl text-gray-700 no-underline font-heading font-bold">
                     { title }
                 </a>
+            </Link>
+        </li>
+    )
+}
+
+function userMenuItem(title, href, icon) {
+    return (
+        <li key={ href } className="px-8 py-4">
+            <Link href={ href }>
+                <span className="block cursor-pointer text-gray-700 no-underline font-heading font-bold">
+                    <FontAwesomeIcon icon={ icon } className="mr-4" fixedWidth />
+                    { title }
+                </span>
             </Link>
         </li>
     )

--- a/styles/index.css
+++ b/styles/index.css
@@ -142,4 +142,12 @@ body.modal-active {
     opacity: .96;
 }
 
+
+/*Dropdown User Menu */
+
+.dropdown:hover .dropdown-menu {
+    display: block;
+    width: 220px;
+}
+
 @import "tailwindcss/utilities";


### PR DESCRIPTION
Because both links were wanted, registration and cloud, I implemented a simple dropdown menu:

![Desktop User Menu](https://user-images.githubusercontent.com/20643018/131089958-c851bd57-8b2e-4843-8678-d873374322a0.png)

On mobile, I kept it as simple as possible:

![Mobile User Menu](https://user-images.githubusercontent.com/20643018/131090029-11b2dbbc-f870-4470-b4ef-f12cdd8fefc8.png)

**Currently blocked** because the menu contains dummy links. Can be merged as soon as the correct links are known. (I however like the links I chose and hope they can stay that way...)

Please test it locally :)