### PR TITLE
Fix unresponsive Prüfungen site 

### DIFF
--- a/content/faq/pruefungen.md
+++ b/content/faq/pruefungen.md
@@ -175,7 +175,7 @@ Das Praxissemester kann erst angetreten werden, wenn das Grundstudium vollständ
 
 ### Was für Löhne sind üblich?
 
-Schau auf unsere Wiki-Seite: https://www.hska.info/vorlesungen/unterlagen/praxistaetigkeit oder auch im Forum 
+Schau auf unsere [Wiki-Seite](https://www.hska.info/vorlesungen/unterlagen/praxistaetigkeit) oder auch im Forum.
 
 
 ## Prüfungsan- und -abmeldung


### PR DESCRIPTION
Don't know why this Link bug only happens on bigger screens. Nevertheless, it fixes the issue.

But anyways....as we want to shut down the old page maybe we should change the information or the link 😄 
Suggestions welcomed!

Test with Devtools:

<img width="748" alt="Screenshot 2021-12-16 at 23 29 42" src="https://user-images.githubusercontent.com/28257108/146458562-fbd4e287-706e-4ed5-b505-07689e322d17.png">
