### PR TITLE
Fix: Missing empty line in comment

### DIFF
--- a/content/pages/vorkurs.md
+++ b/content/pages/vorkurs.md
@@ -207,10 +207,10 @@ Alte Folien
 
 - [Link zu den Folien von Java](https://drive.google.com/file/d/1kno1E5dUxOEHvu2u5BDG1EBMU6hRIRl1/view?usp=sharing)
 - [Link zu der Aufgabe 3 Java](https://drive.google.com/file/d/1DBWMHgOXctNJqtBHXXEatQ6rSnwaCQWV/view?usp=sharing)
-
 - [Link zu den Folien von Python](https://drive.google.com/file/d/190ndeb2Yi6aVuDFoTboiU3WekKX7Fs5n/view?usp=sharing)
 - [Link zu der Aufgabe 3 von Python](https://drive.google.com/file/d/1Cc7vsQHFesh4s35S_gtZlPiaAjuJFw_d/view?usp=sharing)
 - [Link zu den Lösungen der Aufgabe 3 von Python](https://drive.google.com/file/d/1K8fIDUzI1JiLLG86ZGiz9EVF1XtAv1NN/view?usp=sharing)
+
 <!--
 * [Link zu den Folien von C#](https://drive.google.com/file/d/1awsQUXVOXdpSU6U8sDkOi5mcacBI9LIo/view?usp=sharing)
 * [Link zu der Aufgabe 3 C#](https://drive.google.com/file/d/1OP9_ZYxYcFXpRvnPOeZe7RNPWJ1wHwQP/view?usp=sharing)


### PR DESCRIPTION
Die Markdown renderer von GitHub und unserer Seite behandeln Kommentare unterschiedlich... 

![image](https://user-images.githubusercontent.com/28257108/190221675-cbc0a82d-64fb-487e-9095-de3661f30476.png)
