### PR TITLE
revert #171

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,5 @@ jobs:
           ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
           local_path: out # Folder to deploy
           remote_path: ${{ secrets.sftp_remote_path_webspace }}
-          delete_remote_files: true
           args: '-o ConnectTimeout=5'
 


### PR DESCRIPTION
> Reverting #171 to get pipeline running again

The used GitHub Action [deletes the files on the server](https://github.com/wlixcc/SFTP-Deploy-Action/blob/master/entrypoint.sh#L48) with ssh. We currently can't use ssh on our ftp server. Therefore reverting this change.

I can imagine how to fix this, but no time till end of the week...😅
